### PR TITLE
Updated minimum requirement for asgiref.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'six',
         'redis>=2.10',
         'msgpack-python',
-        'asgiref>=0.13',
+        'asgiref>=0.13.3',
     ],
     extras_requires={
         "cryptography": ['cryptography>=1.3.0'],


### PR DESCRIPTION
Hi,

The changes in 0.13 are using valid_channel_name only available in asgiref 0.13.3 and up.